### PR TITLE
fixed parsing and converting of empty blocks (scopes)

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -7,6 +7,7 @@ function NginxParseTreeNode(name, value, parent, children) {
 	this.children = children || [];
 	this.comments = [];
 	this.isVerbatim = false;
+	this.isBlock = !!children;
 }
 
 function NginxParser() {
@@ -20,7 +21,7 @@ function NginxParser() {
 NginxParser.prototype.parse = function(source, callback) {
 	this.source = source;
 	this.index = 0;
-	this.tree = new NginxParseTreeNode('[root]');
+	this.tree = new NginxParseTreeNode('[root]', '', null, []);
 	this.context = new NginxParseTreeNode(null, null, this.tree);
 	this.error = null;
 
@@ -65,6 +66,9 @@ NginxParser.prototype.parseNext = function() {
 				this.context.isVerbatim = true;
 				this.context = new NginxParseTreeNode(null, null, this.context.parent);
 			} else {
+				if (c === '{') {
+					this.context.isBlock = true;
+				}
 				//new context is child of current context, or a sibling to the parent
 				this.context = new NginxParseTreeNode(null, null, c === '{' ? this.context : this.context.parent);
 			}

--- a/tests/conf-tests.js
+++ b/tests/conf-tests.js
@@ -276,6 +276,21 @@ describe('configuration editing', function() {
 			});
 		});
 
+		it('should add new empty block', function(done) {
+			NginxConfFile.createFromSource('', function(err, file) {
+				should.not.exist(err);
+				should.exist(file);
+				file.nginx._add('events', '', []);
+
+				file.nginx.should.have.property('events');
+				file.nginx.events.should.have.property('_name', 'events');
+				file.nginx.events.should.have.property('__isBlock', true);
+
+				file.toString().should.equal('events {\n}\n');
+				done();
+			});
+		});
+
 		it('should create an array for multiple items', function(done) {
 			NginxConfFile.createFromSource('foo bar;', function(err, file) {
 				should.not.exist(err);

--- a/tests/files/expected.conf
+++ b/tests/files/expected.conf
@@ -4,9 +4,6 @@ pid /var/run/nginx.pid;
 #                          [ debug | info | notice | warn | error | crit ]
 error_log /var/log/nginx.error_log  info;
 events {
-    connections 2000;
-# use [ kqueue | rtsig | epoll | /dev/poll | select | poll ];
-    use kqueue;
 }
 http {
     include conf/mime.types;
@@ -91,6 +88,8 @@ http {
             root /spool/www;
             access_log off;
             expires 30d;
+        }
+        location /empty {
         }
         error_page 404  /404.html;
     }

--- a/tests/files/nginx-home.conf
+++ b/tests/files/nginx-home.conf
@@ -8,12 +8,7 @@ pid /var/run/nginx.pid;
 
 error_log  /var/log/nginx.error_log  info;
 
-events {
-    connections   2000;
-
-    # use [ kqueue | rtsig | epoll | /dev/poll | select | poll ];
-    use kqueue;
-}
+events {}
 
 http {
 
@@ -133,6 +128,9 @@ http {
             root         /spool/www;
             access_log   off;
             expires      30d;
+        }
+
+        location /empty {
         }
     }
 }

--- a/tests/parser-tests.js
+++ b/tests/parser-tests.js
@@ -400,6 +400,17 @@ describe('parser', function() {
 				done();
 			});
 		});
+
+		it('should parse empty scope', function(done) {
+			parser.parse('foo {}', function(err, tree) {
+				should.not.exist(err);
+				should.exist(tree);
+				tree.children.should.have.length(1);
+				tree.children[0].should.have.property('name', 'foo');
+				tree.children[0].children.should.have.length(0);
+				done();
+			});
+		});
 	});
 
 	describe('invalid and weird syntax', function() {


### PR DESCRIPTION
Empty blocks are valid in nginx and they have legitimate uses, but nginx-conf does not handle them correctly now:

    NginxConfFile.createFromSource("events {}", function(err, file) {
      file.toString()  // => "events;"
    })