### PR TITLE
support uniform access to single-value and multi-value directives

### DIFF
--- a/src/conf.js
+++ b/src/conf.js
@@ -26,6 +26,12 @@ function createConfItem(file, context, node) {
 					this[name].splice(index, 1);
 					if (this[name].length === 1) {
 						this[name] = this[name][0];
+						//allow uniform access to single-value and multi-value directives.
+						Object.defineProperty(this[name], '0', {
+							configurable: true,
+							enumerable: false,
+							get: function() { return this; }
+						});
 					}
 					file.emit('removed', node);
 				}
@@ -166,6 +172,12 @@ function createConfItem(file, context, node) {
 		context[name].push(newContext);
 	} else {
 		context[name] = newContext;
+		//allow uniform access to single-value and multi-value directives.
+		Object.defineProperty(context[name], '0', {
+			configurable: true,
+			enumerable: false,
+			get: function() { return this; }
+		});
 	}
 
 	if (children) {

--- a/tests/conf-tests.js
+++ b/tests/conf-tests.js
@@ -104,6 +104,32 @@ describe('configuration editing', function() {
 				done();
 			});
 		});
+
+		it('uniform access to single-value and multi-value directives', function(done) {
+			NginxConfFile.createFromSource('foo a;', function(err, file) {
+				should.not.exist(err);
+				should.exist(file);
+
+				file.nginx.should.have.property('foo');
+				file.nginx.foo.should.have.property('_value', 'a');
+				file.nginx.foo.should.have.property('0');
+				file.nginx.foo[0].should.have.property('_value', 'a');
+
+				file.nginx.foo[0]._value = 'ax';
+				file.nginx.foo.should.have.property('_value', 'ax');
+
+				file.nginx._add('foo', 'b');
+				file.nginx.foo[0].should.have.property('_value', 'ax');
+				file.nginx.foo[1].should.have.property('_value', 'b');
+				file.nginx.foo.should.not.have.property('_value');
+
+				file.nginx._remove('foo');
+				file.nginx.foo.should.have.property('_value', 'b');
+				file.nginx.foo[0].should.have.property('_value', 'b');
+
+				done();
+			});
+		});
 	});
 
 	describe('events', function() {


### PR DESCRIPTION
This ensures that `nginx.http.include[0]` will always work whether there's just one `include` defined or multiple.

CI results: https://travis-ci.com/github/jirutka/nginx-conf/builds/210334891 (all green).