### PR TITLE
added support for go syntax

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -86,6 +86,11 @@ export class NginxParser {
 
 		switch (c) {
 			case '{':
+				if ((this.index < this.source.length -1) && (this.source.charAt(this.index + 1) == '{')) {
+					this.context.value += this.readBlockPattern();
+					break;
+				}
+	
 			case ';':
 				this.context.value = this.context.value.trim();
 				if (!this.context.parent) {
@@ -264,7 +269,18 @@ export class NginxParser {
 
 		return result.replace(/^{/, '').replace(/}$/, '');
 	}
-
+	
+	public readBlockPattern(): string {
+		var result = /^({{)(.+?)(}})/.exec(this.source.substring(this.index));
+		if (!result) {
+			this.setError('Block not terminated. Are you missing "}}" ?');
+			return '';
+		}
+		this.index += result[0].length;
+		var block = result[0];
+		return block;
+	}
+	
 	public parseFile(
 		file: string,
 		encoding = 'utf8',

--- a/tests/parser-tests.js
+++ b/tests/parser-tests.js
@@ -221,6 +221,28 @@ describe('parser', function() {
 		});
 	});
 
+	it('should parse double handlebar delimited template expression', function(done) {
+		parser.parse('port {{var}};', function(err, tree) {
+			should.not.exist(err);
+			should.exist(tree);
+			tree.children.should.have.length(1);
+			tree.children[0].should.have.property('name', 'port');
+			tree.children[0].should.have.property('value', '{{var}}');
+			done();
+		});
+	});
+
+	it('should parse double handlebar delimited template expression with variable declaration', function(done) {
+		parser.parse('port {{env "var"}};', function(err, tree) {
+			should.not.exist(err);
+			should.exist(tree);
+			tree.children.should.have.length(1);
+			tree.children[0].should.have.property('name', 'port');
+			tree.children[0].should.have.property('value', '{{env "var"}}');
+			done();
+		});
+	});
+
 	describe('scopes', function() {
 		it('should parse children', function(done) {
 			parser.parse('foo { bar; }', function(err, tree) {
@@ -483,6 +505,14 @@ describe('parser', function() {
 		it('missing closing brace should not throw', function(done) {
 			parser.parse('foo { bar;', function(err) {
 				should.not.exist(err);
+				done();
+			});
+		});
+
+		it('go block not properly terminated with "}}"', function(done) {
+			parser.parse('port {{env "port"}', function(err, tree) {
+				should.exist(err);
+				err.should.have.property('message', 'Block not terminated. Are you missing "}}" ?');
 				done();
 			});
 		});


### PR DESCRIPTION
This is a great project! We use it for all our nginx deployments.  
We have a scenario where we need the ability to parse double handlebars as used in go. 

like so,
`port {{env "port"}}`

We currently use the following code in our deployments for a year or better now.  We would like to contribute this to the larger community.
