### PR TITLE
added support for double handlebar syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,14 @@ console.log(conf.nginx.foo[0]._value); //bar
 console.log(conf.nginx.foo[0]._comments.length); //0
 ```
 
+### Parser options
+Support for go template syntax is provided via `NginxParserOptions`.  By default, templating syntax is not supported.
+
+To enable templating syntax, pass the following `NginxParserOptions` to the `parser.parse` or `parser.parseFile` function(s):
+```json
+{templateSyntax: true}
+```
+
 ## Development
 ```bash
 git clone git@github.com:tmont/nginx-conf.git

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -29,21 +29,25 @@ export interface NginxParseError {
 	line: number;
 }
 
+export interface NginxParseOptions {
+	templateSyntax: boolean;
+}
+
 export class NginxParser {
 	private source = '';
 	private index = -1;
 	private context: NginxParseTreeNode | null = null;
 	private tree: NginxParseTreeNode | null = null;
 	private error: NginxParseError | null = null;
-	private options: {goSyntax: false};
+	private options: NginxParseOptions = {templateSyntax: false};
 
-	public constructor(options?: {goSyntax: false}) {
+	public constructor(options?: NginxParseOptions) {
 		this.source = '';
 		this.index = -1;
 		this.tree = null;
 		this.context = null;
 		this.error = null;
-		(!options) ? this.options = {goSyntax: false} : this.options = options;
+		this.options = options || {templateSyntax: false};
 	}
 
 	public parse(source: string, callback?: (err: Error | null, tree?: NginxParseTreeNode) => void): void {
@@ -88,7 +92,7 @@ export class NginxParser {
 
 		switch (c) {
 			case '{':
-				if ((this.options.goSyntax && this.index < this.source.length -1) && (this.source.charAt(this.index + 1) == '{')) {
+				if ((this.options.templateSyntax && this.index < this.source.length -1) && (this.source.charAt(this.index + 1) == '{')) {
 					this.context.value += this.readBlockPattern();
 					break;
 				} 
@@ -298,10 +302,10 @@ export class NginxParser {
 	}
 }
 
-export const parse = (source: string, callback: (err: Error | null, tree?: NginxParseTreeNode) => void, options?: {goSyntax: false}): void => {
+export const parse = (source: string, callback: (err: Error | null, tree?: NginxParseTreeNode) => void, options?: NginxParseOptions): void => {
 	new NginxParser(options).parse(source, callback);
 };
 
-export const parseFile = (file: string, encoding: string, callback: (err: Error | null, tree?: NginxParseTreeNode) => void, options?: {goSyntax: false}): void => {
+export const parseFile = (file: string, encoding: string, callback: (err: Error | null, tree?: NginxParseTreeNode) => void, options?: NginxParseOptions): void => {
 	new NginxParser(options).parseFile(file, encoding, callback);
 }

--- a/tests/parser-tests.js
+++ b/tests/parser-tests.js
@@ -229,7 +229,7 @@ describe('parser', function() {
 			tree.children[0].should.have.property('name', 'port');
 			tree.children[0].should.have.property('value', '{{var}}');
 			done();
-		}, {goSyntax: true});
+		}, {templateSyntax: true});
 	});
 
 	it('should parse double handlebar delimited template expression with variable declaration', function(done) {
@@ -240,7 +240,7 @@ describe('parser', function() {
 			tree.children[0].should.have.property('name', 'port');
 			tree.children[0].should.have.property('value', '{{env "var"}}');
 			done();
-		}, {goSyntax: true});
+		}, {templateSyntax: true});
 	});
 
 	describe('scopes', function() {
@@ -514,7 +514,7 @@ describe('parser', function() {
 				should.exist(err);
 				err.should.have.property('message', 'Block not terminated. Are you missing "}}" ?');
 				done();
-			}, {goSyntax: true});
+			}, {templateSyntax: true});
 		});
 	});
 

--- a/tests/parser-tests.js
+++ b/tests/parser-tests.js
@@ -221,6 +221,28 @@ describe('parser', function() {
 		});
 	});
 
+	it('should parse double handlebar delimited template expression', function(done) {
+		parser.parse('port {{var}};', function(err, tree) {
+			should.not.exist(err);
+			should.exist(tree);
+			tree.children.should.have.length(1);
+			tree.children[0].should.have.property('name', 'port');
+			tree.children[0].should.have.property('value', '{{var}}');
+			done();
+		}, {goSyntax: true});
+	});
+
+	it('should parse double handlebar delimited template expression with variable declaration', function(done) {
+		parser.parse('port {{env "var"}};', function(err, tree) {
+			should.not.exist(err);
+			should.exist(tree);
+			tree.children.should.have.length(1);
+			tree.children[0].should.have.property('name', 'port');
+			tree.children[0].should.have.property('value', '{{env "var"}}');
+			done();
+		}, {goSyntax: true});
+	});
+
 	describe('scopes', function() {
 		it('should parse children', function(done) {
 			parser.parse('foo { bar; }', function(err, tree) {
@@ -485,6 +507,14 @@ describe('parser', function() {
 				should.not.exist(err);
 				done();
 			});
+		});
+
+		it('go block not properly terminated with "}}"', function(done) {
+			parser.parse('port {{env "port"}', function(err, tree) {
+				should.exist(err);
+				err.should.have.property('message', 'Block not terminated. Are you missing "}}" ?');
+				done();
+			}, {goSyntax: true});
 		});
 	});
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
 		"types": [
 			"node"
 		],
+		"incremental": true,
 		"tsBuildInfoFile": "tsconfig.tsbuildinfo"
 	},
 	"files": [


### PR DESCRIPTION
Updates from #31 review...

1. pulling from master
2. Added `NginxParseOptions` to default ignore double handlebars.  Allow user to opt in. to enable, User can set `templateSyntax` to true as an additional optional parameter to the parse functions.  existing clients are not impacted.

This is a great project! We use it for all our nginx deployments.
We have a scenario where we need the ability to parse double handlebars as used in go.

like so,
port {{env "port"}}

We currently use the following code in our deployments for a year or better now. We would like to contribute this to the larger community.